### PR TITLE
Fixes Directive unsubscribe error

### DIFF
--- a/src/swal.directive.ts
+++ b/src/swal.directive.ts
@@ -119,9 +119,12 @@ export class SwalDirective implements OnInit, OnDestroy {
         if (this.swalRef) {
             this.swalRef.destroy();
         }
-
-        this.confirmSubscription.unsubscribe();
-        this.cancelSubscription.unsubscribe();
+        if(this.confirmSubscription){
+            this.confirmSubscription.unsubscribe();
+        }
+        if(this.cancelSubscription) {
+            this.cancelSubscription.unsubscribe();
+        }
     }
 
     /**


### PR DESCRIPTION
Fixes:
```
core.js:1350 ERROR Error: Uncaught (in promise): TypeError: Cannot read property 'unsubscribe' of undefined
TypeError: Cannot read property 'unsubscribe' of undefined
    at SwalDirective.ngOnDestroy (ngx-sweetalert2.es5.js:339)
```

If confirm or cancel are not defined.