### PR TITLE
Explicitly specify sweetalert2@7 in the installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ This is not a regular API wrapper for SweetAlert (which already works very well 
 1) Install _ngx-sweetalert2_ and _sweetalert2_ via the npm registry:
 
 ```bash
-npm install --save sweetalert2 @toverux/ngx-sweetalert2
+npm install --save sweetalert2@7 @toverux/ngx-sweetalert2
 ```
 
 :arrow_double_up: Always upgrade SweetAlert2 when you upgrade ngx-sweetalert2. The latter is statically linked with SweetAlert2's type definitions.


### PR DESCRIPTION
Fixes #101 

`npm install --save sweetalert2 @toverux/ngx-sweetalert2` will install the latest major version of `sweetalert2` which isn't supported by `ngx-sweetalert2`:

![image](https://user-images.githubusercontent.com/6059356/51437716-8ac9a680-1caa-11e9-8af8-68b95b2bd94a.png)
