### PR TITLE
Be even more explicit about the swal2 version

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ This is not a regular API wrapper for SweetAlert (which already works very well 
 1) Install _ngx-sweetalert2_ and _sweetalert2_ via the npm registry:
 
 ```bash
-npm install --save sweetalert2@7 @toverux/ngx-sweetalert2
+npm install --save sweetalert2@^7.15.1 @toverux/ngx-sweetalert2
 ```
 
 :arrow_double_up: Always upgrade SweetAlert2 when you upgrade ngx-sweetalert2. The latter is statically linked with SweetAlert2's type definitions.


### PR DESCRIPTION
Follow-up for #102 

the result of `npm i sweetalert2@7`:

```js
  "dependencies": {
    "sweetalert2": "^7.0.0"
  }
```

the result of `yarn add sweetalert2@7`:

```js
  "dependencies": {
    "sweetalert2": "7"
  }
```

JS package managers are inconsistent in their behavior, so let's be explicit about our intentions to get the same result for npm and yarn.